### PR TITLE
Fixed first level subcommand registration

### DIFF
--- a/src/DiscordCommandRegistry.php
+++ b/src/DiscordCommandRegistry.php
@@ -52,7 +52,7 @@ class DiscordCommandRegistry
                         $subCommandGroupDescription = (new $subCommandGroup)->description();
                     }
 
-                    $subCommandGroups[] = DiscordApplicationCommandOption::new(name: $subGroupName, type: CommandOptionType::SUB_COMMAND_GROUP)
+                    $subCommandGroups[] = DiscordApplicationCommandOption::new(name: $subGroupName, type: ($subCommands === []) ? CommandOptionType::SUB_COMMAND : CommandOptionType::SUB_COMMAND_GROUP)
                         ->setDescription($subCommandGroupDescription)
                         ->setOptions(($subCommands === []) ? null : DiscordApplicationCommandOption::collect(collect($subCommands)));
                 }


### PR DESCRIPTION
This PR fixes first level subcommand registration:

```php
DiscordCommandRegistry::setCommands([
    'test' => [
        'command' => TestCommand::class,
    ],
]);
```

Previously, it would incorrectly register `TestCommand` as sub command group even though it's the last in the chain. Now it will correctly handle these cases and register them as sub commands.