### PR TITLE
Fix message attachment reset

### DIFF
--- a/src/Data/DiscordMessage.php
+++ b/src/Data/DiscordMessage.php
@@ -84,4 +84,15 @@ class DiscordMessage extends Data
     {
         return $this->files->isNotEmpty();
     }
+
+    public function toArray(): array
+    {
+        $array = parent::toArray();
+
+        if ($this->attachments === null) {
+            unset($array['attachments']);
+        }
+
+        return $array;
+    }
 }


### PR DESCRIPTION
Do not pass empty `attachments` parameter if it is `null`. To remove message attachments set it to empty array `[]` or use `->removeAttachments()` method.