### PR TITLE
Added ability to provide command input options

### DIFF
--- a/src/Contracts/HasCommandOptions.php
+++ b/src/Contracts/HasCommandOptions.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Plytas\Discord\Contracts;
+
+use Illuminate\Support\Collection;
+use Plytas\Discord\Data\DiscordApplicationCommandOption;
+
+interface HasCommandOptions
+{
+    /**
+     * @return Collection<int, DiscordApplicationCommandOption>
+     */
+    public function commandOptions(): Collection;
+}

--- a/src/Data/DiscordApplicationCommand.php
+++ b/src/Data/DiscordApplicationCommand.php
@@ -11,6 +11,7 @@ class DiscordApplicationCommand extends Data
     public function __construct(
         public string $name,
         public CommandType $type,
+        public ?string $id = null,
         public ?string $description = null,
         /** @var Collection<int, DiscordApplicationCommandOption> */
         public ?Collection $options = null,
@@ -36,19 +37,5 @@ class DiscordApplicationCommand extends Data
         $this->options = $options;
 
         return $this;
-    }
-
-    public function getCommandStructure(): string
-    {
-        return $this->name.$this->getOptionName($this->options?->first());
-    }
-
-    private function getOptionName(?DiscordApplicationCommandOption $option): string
-    {
-        if (! $option instanceof DiscordApplicationCommandOption) {
-            return '';
-        }
-
-        return '.'.$option->name.$this->getOptionName($option->options?->first());
     }
 }

--- a/src/Data/DiscordApplicationCommandOption.php
+++ b/src/Data/DiscordApplicationCommandOption.php
@@ -14,6 +14,7 @@ class DiscordApplicationCommandOption extends Data
         public ?string $description = null,
         /** @var Collection<int, DiscordApplicationCommandOption> */
         public ?Collection $options = null,
+        public bool $required = false,
     ) {}
 
     public static function new(string $name, CommandOptionType $type): self
@@ -34,6 +35,13 @@ class DiscordApplicationCommandOption extends Data
     public function setOptions(?Collection $options): self
     {
         $this->options = $options;
+
+        return $this;
+    }
+
+    public function setRequired(bool $required = true): self
+    {
+        $this->required = $required;
 
         return $this;
     }

--- a/src/Data/DiscordInteraction.php
+++ b/src/Data/DiscordInteraction.php
@@ -22,7 +22,7 @@ class DiscordInteraction extends Data
          */
         public ?array $data = [],
 
-        private ?DiscordApplicationCommand $applicationCommand = null,
+        private ?DiscordInteractionApplicationCommand $applicationCommand = null,
         private ?DiscordMessageComponent $messageComponent = null,
         private ?DiscordModalComponent $modalComponent = null,
     ) {}
@@ -47,9 +47,9 @@ class DiscordInteraction extends Data
         return DiscordResponse::showModal($modal);
     }
 
-    public function getApplicationCommand(): DiscordApplicationCommand
+    public function getApplicationCommand(): DiscordInteractionApplicationCommand
     {
-        return $this->applicationCommand ??= DiscordApplicationCommand::from($this->data);
+        return $this->applicationCommand ??= DiscordInteractionApplicationCommand::from($this->data);
     }
 
     public function getMessageComponent(): DiscordMessageComponent

--- a/src/Data/DiscordInteractionApplicationCommand.php
+++ b/src/Data/DiscordInteractionApplicationCommand.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace Plytas\Discord\Data;
+
+use Illuminate\Support\Collection;
+use Plytas\Discord\Enums\CommandType;
+use Spatie\LaravelData\Data;
+
+class DiscordInteractionApplicationCommand extends Data
+{
+    public function __construct(
+        public string $id,
+        public string $name,
+        public CommandType $type,
+        /** @var Collection<int, DiscordInteractionApplicationCommandOption> */
+        public ?Collection $options = null,
+    ) {}
+
+    /**
+     * @return Collection<string, mixed>
+     */
+    public function getKeyedOptionValues(): Collection
+    {
+        $values = [];
+
+        foreach ($this->options ?? [] as $commandOption) {
+            if ($commandOption->type->isSubcommandOrGroup()) {
+                foreach ($commandOption->options ?? [] as $subCommandGroupOption) {
+                    if ($subCommandGroupOption->type->isSubcommandOrGroup()) {
+                        foreach ($subCommandGroupOption->options ?? [] as $subCommandOption) {
+                            $values[$subCommandOption->name] = $subCommandOption->value;
+                        }
+
+                        continue;
+                    }
+
+                    $values[$subCommandGroupOption->name] = $subCommandGroupOption->value;
+                }
+
+                continue;
+            }
+
+            $values[$commandOption->name] = $commandOption->value;
+        }
+
+        return collect($values);
+    }
+
+    public function getCommandStructure(): string
+    {
+        return $this->name.$this->getOptionName($this->options?->first());
+    }
+
+    private function getOptionName(?DiscordInteractionApplicationCommandOption $option): string
+    {
+        if (! $option instanceof DiscordInteractionApplicationCommandOption) {
+            return '';
+        }
+
+        if (! $option->type->isSubcommandOrGroup()) {
+            return '';
+        }
+
+        return '.'.$option->name.$this->getOptionName($option->options?->first());
+    }
+}

--- a/src/Data/DiscordInteractionApplicationCommandOption.php
+++ b/src/Data/DiscordInteractionApplicationCommandOption.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Plytas\Discord\Data;
+
+use Illuminate\Support\Collection;
+use Plytas\Discord\Enums\CommandOptionType;
+use Spatie\LaravelData\Data;
+
+class DiscordInteractionApplicationCommandOption extends Data
+{
+    public function __construct(
+        public string $name,
+        public CommandOptionType $type,
+        public mixed $value = null,
+        /** @var Collection<int, DiscordInteractionApplicationCommandOption> */
+        public ?Collection $options = null,
+    ) {}
+}

--- a/src/Enums/CommandOptionType.php
+++ b/src/Enums/CommandOptionType.php
@@ -15,4 +15,13 @@ enum CommandOptionType: int
     case MENTIONABLE = 9;
     case NUMBER = 10;
     case ATTACHMENT = 11;
+
+    public function isSubcommandOrGroup(): bool
+    {
+        return match ($this) {
+            CommandOptionType::SUB_COMMAND,
+            CommandOptionType::SUB_COMMAND_GROUP => true,
+            default => false,
+        };
+    }
 }


### PR DESCRIPTION
> [!WARNING]
> ### Breaking change:
> `DiscordInteraction::getApplicationCommand()` will now return an instance of `DiscordInteractionApplicationCommand`.

This pull request introduces several changes to the Discord command handling system, including the addition of new interfaces, refactoring of command structures, and enhancements to command options. The most important changes are summarized below:

### New Interfaces and Classes:
* Added `HasCommandOptions` interface to define a contract for classes that have command options (`src/Contracts/HasCommandOptions.php`).
* Introduced `DiscordInteractionApplicationCommand` and `DiscordInteractionApplicationCommandOption` classes to handle interaction-specific application commands and their options (`src/Data/DiscordInteractionApplicationCommand.php`, `src/Data/DiscordInteractionApplicationCommandOption.php`). [[1]](diffhunk://#diff-5a652a9c8d8e3e29495d0af4f2b111410269191c4a8866a6244ce5d14f7f764bR1-R66) [[2]](diffhunk://#diff-9fb8a207612c3ad65f8aa31e6d915fdc73982f21742c36dfae9989cad878e1a9R1-R18)

### Enhancements to Command Options:
* Added `required` property to `DiscordApplicationCommandOption` and a corresponding `setRequired` method (`src/Data/DiscordApplicationCommandOption.php`). [[1]](diffhunk://#diff-b19971a61420f3c230921796013d06c43e30d26c5ccf73b1a31ca1be29679f43R17) [[2]](diffhunk://#diff-b19971a61420f3c230921796013d06c43e30d26c5ccf73b1a31ca1be29679f43R41-R47)
* Updated `CommandOptionType` enum to include a method `isSubcommandOrGroup` for checking if an option type is a subcommand or group (`src/Enums/CommandOptionType.php`).

### Refactoring and Cleanup:
* Refactored `DiscordApplicationCommand` to include an optional `id` property and removed redundant methods (`src/Data/DiscordApplicationCommand.php`). [[1]](diffhunk://#diff-12190c7d915bbd2c422bae872b467dbe0460013bbbf07d5068e01eaca57ebb6fR14) [[2]](diffhunk://#diff-12190c7d915bbd2c422bae872b467dbe0460013bbbf07d5068e01eaca57ebb6fL40-L53)
* Updated `DiscordInteraction` to use `DiscordInteractionApplicationCommand` instead of `DiscordApplicationCommand` (`src/Data/DiscordInteraction.php`). [[1]](diffhunk://#diff-c6c2cf9b2fd5ecdb0d0fdb53f8080c320c8c96aacaa9706d67fbb8f954b7613fL25-R25) [[2]](diffhunk://#diff-c6c2cf9b2fd5ecdb0d0fdb53f8080c320c8c96aacaa9706d67fbb8f954b7613fL50-R52)

### Command Registration Enhancements:
* Enhanced `DiscordCommandRegistry` to support commands with options by checking if commands implement `HasCommandOptions` and setting options accordingly (`src/DiscordCommandRegistry.php`). [[1]](diffhunk://#diff-4a93e4894cd8615e2459a9d0dbd595d7cd0688b4a8e36d2a55c6d95a3542462fR8) [[2]](diffhunk://#diff-4a93e4894cd8615e2459a9d0dbd595d7cd0688b4a8e36d2a55c6d95a3542462fR41-R85)

### Usage
Register your commands as usual inside a service provider `boot()` method:
```php
<?php

namespace App\Providers;

use App\Discord\PromptCommand;
use Illuminate\Support\ServiceProvider;
use Plytas\Discord\DiscordCommandRegistry;

class AppServiceProvider extends ServiceProvider
{
    /**
     * Bootstrap any application services.
     */
    public function boot(): void
    {
        DiscordCommandRegistry::setCommands([
            'prompt' => PromptCommand::class, // Works with regular commands

            'nested' => [
                'prompt' => PromptCommand::class, // Also works with nested commands
            ],

            'double' => [
                'nested' => [
                    'prompt' => PromptCommand::class, // And even with double nested commands
                ]
            ],
        ]);
    }
}
```

Implement a new `\Plytas\Discord\Contracts\HasCommandOptions` interface in your command:
```php
namespace App\Discord;

use Illuminate\Support\Collection;
use Plytas\Discord\Contracts\DiscordCommand;
use Plytas\Discord\Contracts\HasCommandOptions;
use Plytas\Discord\Data\DiscordApplicationCommandOption;
use Plytas\Discord\Enums\CommandOptionType;

class PromptCommand implements DiscordCommand, HasCommandOptions
{
    // ... omitted for brevity

    public function commandOptions(): Collection
    {
        return collect([
            DiscordApplicationCommandOption::new('prompt_input', CommandOptionType::STRING)
                ->setDescription('Input description')
                ->setRequired()
        ]);
    }
}
```

Retrieve user input using `$interaction->getApplicationCommand()->getKeyedOptionValues()`:
```php
<?php

namespace App\Discord;

use Plytas\Discord\Contracts\DiscordCommand;
use Plytas\Discord\Contracts\HasCommandOptions;
use Plytas\Discord\Data\DiscordInteraction;
use Plytas\Discord\Data\DiscordMessage;
use Plytas\Discord\Data\DiscordResponse;

class PromptCommand implements DiscordCommand, HasCommandOptions
{
    // ... omitted for brevity

    public function handle(DiscordInteraction $interaction): DiscordResponse
    {
        $values = $interaction->getApplicationCommand()->getKeyedOptionValues();

        return $interaction->respondWithMessage(DiscordMessage::new()
            ->ephemeral()
            ->setContent('User input was: ' . $values->get('prompt_input')));
    }
}
```