### PR TITLE
Add Laravel 13 support

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -27,7 +27,7 @@ jobs:
           - laravel: 10.*
             testbench: 8.*
             carbon: ^2.63
-            pest: ^3.0
+            pest: ^2.0
           - laravel: 11.*
             testbench: 9.*
             carbon: ^3.0

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -27,15 +27,19 @@ jobs:
           - laravel: 10.*
             testbench: 8.*
             carbon: ^2.63
+            pest: ^3.0
           - laravel: 11.*
             testbench: 9.*
             carbon: ^3.0
+            pest: ^3.0
           - laravel: 12.*
             testbench: 10.*
             carbon: ^3.0
+            pest: ^3.0
           - laravel: 13.*
             testbench: 11.*
             carbon: ^3.0
+            pest: ^4.0
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }} - ${{ matrix.os }}
 
@@ -48,7 +52,7 @@ jobs:
         with:
           php-version: ${{ matrix.php }}
           extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, bcmath, soap, intl, gd, exif, iconv, imagick, fileinfo
-          coverage: none
+          coverage: pcov
 
       - name: Setup problem matchers
         run: |
@@ -57,7 +61,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" "nesbot/carbon:${{ matrix.os == 'windows-latest' && '^^^' || '' }}${{ matrix.carbon }}" --no-interaction --no-update
+          composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" "nesbot/carbon:${{ matrix.os == 'windows-latest' && '^^^' || '' }}${{ matrix.carbon }}" "pestphp/pest:${{ matrix.pest }}" --no-interaction --no-update
           composer update --${{ matrix.stability }} --prefer-dist --no-interaction
 
       - name: List Installed Dependencies

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -18,8 +18,11 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest]
         php: [8.3, 8.2]
-        laravel: [10.*, 11.*, 12.*]
+        laravel: [10.*, 11.*, 12.*, 13.*]
         stability: [prefer-lowest, prefer-stable]
+        exclude:
+          - laravel: 13.*
+            php: 8.2
         include:
           - laravel: 10.*
             testbench: 8.*
@@ -29,6 +32,9 @@ jobs:
             carbon: ^3.0
           - laravel: 12.*
             testbench: 10.*
+            carbon: ^3.0
+          - laravel: 13.*
+            testbench: 11.*
             carbon: ^3.0
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }} - ${{ matrix.os }}

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -61,7 +61,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" "nesbot/carbon:${{ matrix.os == 'windows-latest' && '^^^' || '' }}${{ matrix.carbon }}" "pestphp/pest:${{ matrix.pest }}" --no-interaction --no-update
+          composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" "nesbot/carbon:${{ matrix.os == 'windows-latest' && '^^^' || '' }}${{ matrix.carbon }}" "pestphp/pest:${{ matrix.os == 'windows-latest' && '^^^' || '' }}${{ matrix.pest }}" --no-interaction --no-update
           composer update --${{ matrix.stability }} --prefer-dist --no-interaction
 
       - name: List Installed Dependencies

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     ],
     "require": {
         "php": "^8.2",
-        "illuminate/contracts": "^10.0||^11.0||^12.0",
+        "illuminate/contracts": "^10.0||^11.0||^12.0||^13.0",
         "spatie/laravel-data": "^4.6",
         "spatie/laravel-package-tools": "^1.16"
     },
@@ -26,10 +26,10 @@
         "laravel/pint": "^v1.21.0",
         "nunomaduro/collision": "^v8.6.1|^v7.11.0",
         "larastan/larastan": "^v3.1.0|^v2.9.14",
-        "orchestra/testbench": "^v10.0.0",
-        "pestphp/pest": "^v3.7.4|^v2.36.0",
-        "pestphp/pest-plugin-arch": "^v3.0.0|^v2.7.0",
-        "pestphp/pest-plugin-laravel": "^v3.1.0|^v2.3.0",
+        "orchestra/testbench": "^v11.0.0|^v10.0.0",
+        "pestphp/pest": "^v4.0.0|^v3.7.4|^v2.36.0",
+        "pestphp/pest-plugin-arch": "^v4.0.0|^v3.0.0|^v2.7.0",
+        "pestphp/pest-plugin-laravel": "^v4.0.0|^v3.1.0|^v2.3.0",
         "phpstan/extension-installer": "^1.4.3",
         "phpstan/phpstan-deprecation-rules": "^2.0.1|^1.2.1",
         "phpstan/phpstan-phpunit": "^2.0.4|^1.4.2",


### PR DESCRIPTION
## Summary
- Add `^13.0` to `illuminate/contracts` and widen `orchestra/testbench` to `^11.0`
- Widen `pestphp/pest`, `pest-plugin-arch`, `pest-plugin-laravel` constraints to allow `^4.0` (required for L13 compatibility)
- Extend CI matrix with `laravel: 13.*` / `testbench: 11.*` / `carbon: ^3.0`, excluding PHP 8.2 (L13 requires PHP 8.3+)

## Test plan
- [x] `composer update` resolves with Laravel 13 + testbench 11
- [x] `vendor/bin/pest` passes against Laravel 13
- [ ] CI matrix green across all PHP/Laravel/stability combos

🤖 Generated with [Claude Code](https://claude.com/claude-code)