### PR TITLE
Fix PHPStan false positives in package config

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -10,3 +10,6 @@ parameters:
     tmpDir: build/phpstan
     checkOctaneCompatibility: true
     checkModelProperties: true
+    treatPhpDocTypesAsCertain: false
+    configDirectories:
+        - config


### PR DESCRIPTION
## Summary
- `treatPhpDocTypesAsCertain: false` — stops `function.alreadyNarrowedType` from flagging runtime `is_a()` guards (e.g. `DiscordComponentRegistry.php:70`) whose narrowing comes from PHPDoc-declared types, while preserving the runtime guard.
- `configDirectories: [config]` — point Larastan's `noEnvCallsOutsideOfConfig` rule at the package's own `config/`. By default it resolves to `config_path()`, which under testbench is the skeleton's config dir, so `env()` calls in `config/discord-interactions.php` were being misreported.

Both errors are pre-existing on `main`; they only surfaced now because Dependabot PRs (#23, #25) edit `phpstan.yml`, which is one of the paths that re-triggers the PHPStan workflow.

## Test plan
- [x] `vendor/bin/phpstan` reports `[OK] No errors` locally
- [ ] PHPStan workflow green in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)